### PR TITLE
Fix updates failing if download dir does not exist in default location

### DIFF
--- a/lib/widgets/update_dialog.dart
+++ b/lib/widgets/update_dialog.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as path;
+import 'package:path_provider/path_provider.dart';
 import '../services/app_updater_service.dart';
 import '../utils/app_theme.dart';
 
@@ -461,9 +462,8 @@ class _UpdateDialogState extends State<UpdateDialog> with SingleTickerProviderSt
     
     try {
       // Determine download directory and file extension
-      final dir = Platform.isWindows 
-          ? Directory('${Platform.environment['USERPROFILE']}\\Downloads')
-          : Directory('${Platform.environment['HOME']}/Downloads');
+      Directory? downloadsDir = await getDownloadsDirectory();
+      final dir = downloadsDir ?? await getTemporaryDirectory();
       
       final extension = Platform.isWindows ? '.exe' : '.AppImage';
       final fileName = 'PlayTorrio-${widget.updateInfo.latestVersion}$extension';


### PR DESCRIPTION
If a user relocates their download directory then the update process will fail as it tries to use a hard coded location in the users profile folder that doesn't exist. path_provider works for both Linux and Windows as required.